### PR TITLE
replace depreciated property

### DIFF
--- a/src/Models/Person.php
+++ b/src/Models/Person.php
@@ -30,7 +30,9 @@ class Person extends Model
 
     protected $guarded = ['id'];
 
-    protected $dates = ['birthday'];
+    protected $casts = [
+        'birthday' => 'date',
+    ];
 
     protected $touches = ['user'];
 


### PR DESCRIPTION
$dates doesnt exist in laravel 10 their by making it returning as a string and causing error 
<img width="861" alt="image" src="https://github.com/laravel-enso/people/assets/33360580/43a6a434-1432-4d22-b73e-733341bf2f25">
